### PR TITLE
feat: 결제 confirm/webhook 동시 요청 방어 및 트랜잭션 설정 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ bin/
 # 임시 파일 및 로그
 *.log
 *.tmp
+
+
+# 환경 설정 파일
+application.properties

--- a/src/main/java/com/petcation/client/payments/component/PaymentValidator.java
+++ b/src/main/java/com/petcation/client/payments/component/PaymentValidator.java
@@ -21,6 +21,10 @@ public class PaymentValidator {
             log.info("이미 결제 완료된 주문입니다: " + orderId);
             return ValidationResult.ALREADY_DONE;
         }
+        if ("PROCESSING".equals(payment.getStatus())) {
+            log.info("처리 중인 주문입니다: " + orderId);
+            return ValidationResult.IN_PROGRESS;
+        }
         if (!((long) payment.getPrice() == amount)) {
             log.error("ERROR: 금액 불일치! [주문번호: " + orderId + "] DB 저장 금액: " + (long)payment.getPrice() + ", 실제 결제 금액: " + amount);
             return ValidationResult.AMOUNT_MISMATCH;

--- a/src/main/java/com/petcation/client/payments/component/ValidationResult.java
+++ b/src/main/java/com/petcation/client/payments/component/ValidationResult.java
@@ -4,5 +4,6 @@ public enum ValidationResult {
     VALID,
     ALREADY_DONE,
     AMOUNT_MISMATCH,
-    NOT_FOUND
+    NOT_FOUND, 
+    IN_PROGRESS
 }

--- a/src/main/java/com/petcation/client/payments/dao/PaymentsDAO.java
+++ b/src/main/java/com/petcation/client/payments/dao/PaymentsDAO.java
@@ -7,9 +7,12 @@ import com.petcation.client.payments.vo.PaymentsVO;
 public interface PaymentsDAO {
     void createPayment(@Param("order_id") String orderId, @Param("price") int price, @Param("user_no") int userNo);
     PaymentsVO getPayment(String orderId);
-    void completePayment(@Param("payment_key") String paymentKey, @Param("method") String method, @Param("orderId") String orderId);
+    int completePayment(@Param("payment_key") String paymentKey, @Param("method") String method, @Param("orderId") String orderId);
     void updatePaymentStatus(@Param("orderId") String orderId, @Param("status") String status);
-    void cancelPayment(String orderId);
+    int cancelPayment(String orderId);
     void failPayment(String orderId);
     String getPaymentKey(String orderId);
+    int processingPayment(String orderId);
+    int CancelProcessingPayment(String orderId);
+    void revertCancelProcessing(String orderId);
 }

--- a/src/main/java/com/petcation/client/payments/infra/TossProvider.java
+++ b/src/main/java/com/petcation/client/payments/infra/TossProvider.java
@@ -41,13 +41,20 @@ public class TossProvider {
                 .build();
             
             HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-            
+
             log.info("응답 상태 코드: " + response.statusCode());
             log.info("응답 바디: " + response.body());
             
+            JsonObject jsonObject;
+            try {
+                jsonObject = JsonParser.parseString(response.body()).getAsJsonObject();
+            } catch (Exception parseEx) {
+                log.error("결제 응답 파싱 실패: " + parseEx.getMessage());
+                return TossResponseDto.fail("PARSE_ERROR", "결제 응답을 처리할 수 없습니다.");
+            }
+            
             if (response.statusCode() == 200) {
-                String responseBody = response.body();
-                JsonObject jsonObject = JsonParser.parseString(responseBody).getAsJsonObject();
+                
                 String status = jsonObject.get("status").getAsString();
                 if ("DONE".equals(status)) {
                     String method = jsonObject.get("method").getAsString();
@@ -58,12 +65,14 @@ public class TossProvider {
                         jsonObject.get("paymentKey").getAsString()
                     );
                 }
+                log.warn("결제 미완료 상태 [status: " + status + "] 주문번호: " + orderId);
+                return TossResponseDto.fail(status, "결제가 완료되지 않았습니다. status=" + status);
             }
             String responseBody = response.body();
             JsonObject errorObject = JsonParser.parseString(responseBody).getAsJsonObject();
             
-            String errorCode = errorObject.get("code").getAsString();
-            String errorMessage = errorObject.get("message").getAsString();
+            String errorCode = jsonObject.has("code") ? jsonObject.get("code").getAsString() : "CONFIRM_FAILED";
+            String errorMessage = jsonObject.has("message") ? jsonObject.get("message").getAsString() : "결제 승인 실패";
             
             log.error("결제 승인 실패 [코드: " + errorCode + "] 메시지: " + errorMessage);
             return TossResponseDto.fail(errorCode, errorMessage);
@@ -84,11 +93,19 @@ public class TossProvider {
                 .header("Content-Type", "application/json")
                 .method("POST", HttpRequest.BodyPublishers.ofString("{\"cancelReason\":\"구매자 변심\"}"))
                 .build();
-            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
-            JsonObject jsonObject = JsonParser.parseString(response.body()).getAsJsonObject();
             
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            JsonObject jsonObject;
+
             log.info("응답 상태 코드: " + response.statusCode());
             log.info("응답 바디: " + response.body());
+            
+            try {
+                jsonObject = JsonParser.parseString(response.body()).getAsJsonObject();
+            } catch (Exception parseEx) {
+                log.error("취소 응답 파싱 실패: " + parseEx.getMessage());
+                return TossResponseDto.fail("PARSE_ERROR", "취소 응답을 처리할 수 없습니다.");
+            }
             
             if (response.statusCode() == 200) {
                 String status = jsonObject.get("status").getAsString();

--- a/src/main/java/com/petcation/client/payments/service/PaymentFacade.java
+++ b/src/main/java/com/petcation/client/payments/service/PaymentFacade.java
@@ -7,10 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.petcation.client.hotel.service.User_HotelService;
-import com.petcation.client.payments.component.PaymentValidator;
 import com.petcation.client.payments.component.ValidationResult;
 import com.petcation.client.payments.infra.TossProvider;
-import com.petcation.client.payments.vo.PaymentsVO;
 import com.petcation.client.payments.vo.TossResponseDto;
 import com.petcation.client.payments.vo.WebhookDto;
 import com.petcation.client.reservation.component.ReservationManager;
@@ -30,7 +28,6 @@ public class PaymentFacade {
     private final User_HotelService hotelService;
     private final PaymentsService paymentsService;
     private final ReservationManager reservationManager;
-    private final PaymentValidator paymentValidator;
     private final TossProvider tossProvider;
     
     @Transactional
@@ -54,8 +51,7 @@ public class PaymentFacade {
     }
 
     public boolean confirmPayment(String paymentKey, String orderId, Long amount) {
-        PaymentsVO payment = paymentsService.getPayment(orderId);
-        ValidationResult result = paymentValidator.validate(payment, orderId, amount);
+        ValidationResult result = paymentsService.claimForProcessing(orderId, amount);
         
         switch (result) {
             case VALID -> {
@@ -83,6 +79,7 @@ public class PaymentFacade {
                 processPaymentFail(orderId);
                 return false;
             }
+            case IN_PROGRESS -> log.info("이미 처리 중인 요청 무시: " + orderId);
         }
         return false;
     }
@@ -95,6 +92,11 @@ public class PaymentFacade {
         ReservVO r = reservService.getReservForCancel(orderId);
         reservationManager.validateCancellation(r, orderId, userNo); // 1. 취소 가능 여부 검증
         
+        boolean claimed = paymentsService.claimForCancel(orderId);
+        if (!claimed) {
+            throw new BadRequestException("이미 취소 처리 중이거나 취소된 결제입니다.");
+        }
+        
         String paymentKey = paymentsService.getPaymentKey(orderId); 
         TossResponseDto result = tossProvider.cancel(paymentKey, orderId); // 2. 결제 취소 (토스 API)
         
@@ -106,15 +108,20 @@ public class PaymentFacade {
                 log.error("[긴급] 토스 취소 완료 / DB 업데이트 실패. 수동 확인 필요. orderId: " + orderId);
                 throw e;
             }
+        } else if ("NETWORK_ERROR".equals(result.getErrorCode())) {
+            // 실제 취소 여부 불확실 - DONE으로 되돌릴 수 없음
+            log.error("[긴급] 토스 취소 응답 유실. 실제 취소 여부 확인 필요. orderId: " + orderId);
+            throw new BadRequestException("취소 처리 확인 중입니다. 잠시 후 다시 시도해주세요.");
         } else {
+            // 취소 실패 시 원래 상태(DONE)로 복구 
+            paymentsService.revertCancelProcessing(orderId);
             throw new BadRequestException(result.getErrorMessage());
         }
     }
 
     public void processWebhook(WebhookDto.PaymentData data) {
-        PaymentsVO payment = paymentsService.getPayment(data.getOrderId());
-        ValidationResult result = paymentValidator.validate(payment, data.getOrderId(), data.getTotalAmount());
-        
+
+        ValidationResult result = paymentsService.claimForProcessing(data.getOrderId(), data.getTotalAmount());        
         switch (data.getStatus()) {
             case "DONE" -> {
                 switch (result) {
@@ -125,10 +132,12 @@ public class PaymentFacade {
                     case AMOUNT_MISMATCH, NOT_FOUND -> {
                         processPaymentFail(data.getOrderId());
                     }
+                    case IN_PROGRESS -> log.info("이미 처리 중인 요청 무시: " + data.getOrderId());
                 }
             }
             case "CANCELED" -> {
-                if (!"CANCELED".equals(payment.getStatus())) {
+                boolean claimed = paymentsService.claimForCancel(data.getOrderId());
+                if (claimed) {
                     processPaymentCancel(data.getOrderId());
                 } else {
                     log.debug("이미 취소 처리된 주문 webhook 무시: " + data.getOrderId());

--- a/src/main/java/com/petcation/client/payments/service/PaymentsService.java
+++ b/src/main/java/com/petcation/client/payments/service/PaymentsService.java
@@ -1,7 +1,10 @@
 package com.petcation.client.payments.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.petcation.client.payments.component.PaymentValidator;
+import com.petcation.client.payments.component.ValidationResult;
 import com.petcation.client.payments.dao.PaymentsDAO;
 import com.petcation.client.payments.vo.PaymentsVO;
 
@@ -13,6 +16,7 @@ import lombok.extern.log4j.Log4j;
 @Log4j
 public class PaymentsService {
 
+    private final PaymentValidator paymentValidator;
 	private final PaymentsDAO paymentsDao;
 	
 	public void createPayment(String paymentId, int price, int userNo) {
@@ -21,7 +25,11 @@ public class PaymentsService {
 	
     // DB 업데이트 로직
     public void updatePaymentComplete(String orderId, String paymentKey, String method) {
-        paymentsDao.completePayment(orderId, paymentKey, method);
+        int updated = paymentsDao.completePayment(paymentKey, method, orderId);
+        if (updated == 0) {
+            log.error("[경고] 결제 완료 처리 실패 - 예상 상태(PROCESSING) 아님. orderId: " + orderId);
+            throw new IllegalStateException("결제 완료 처리 중 상태 불일치 발생: " + orderId);
+        }
         log.info("결제 완료: 주문번호 "+ orderId);
     }
     
@@ -30,7 +38,12 @@ public class PaymentsService {
     }
 
     public void cancelPayment(String orderId) {
-        paymentsDao.cancelPayment(orderId);
+        int updated = paymentsDao.cancelPayment(orderId);
+        if (updated == 0) {
+            log.error("[경고] 결제 상태를 CANCELED로 바꾸지 못했습니다. - 예상 상태(CANCEL_PROCESSING) 아님. orderId: " + orderId);
+            throw new IllegalStateException("결제 취소 처리 중 상태 불일치 발생: " + orderId);
+        }
+        log.info("결제 취소 완료: 주문번호 "+ orderId);
     }
     
     public PaymentsVO getPayment(String orderId) {
@@ -39,5 +52,51 @@ public class PaymentsService {
 
     public String getPaymentKey(String orderId) {
         return paymentsDao.getPaymentKey(orderId);
+    }
+
+    @Transactional
+    public ValidationResult claimForProcessing(String orderId, Long amount) {
+        
+        PaymentsVO payment = getPayment(orderId);
+        log.info("[DEBUG] claimForProcessing 진입 - orderId: " + orderId + ", 현재 status: " + payment.getStatus() + ", thread: " + Thread.currentThread().getName());
+        ValidationResult result = paymentValidator.validate(payment, orderId, amount);
+        if (result == ValidationResult.VALID) {
+            updatePaymentProcessing(orderId);
+        }
+        return result;
+    }
+
+    private void updatePaymentProcessing(String orderId) {
+        int updated = paymentsDao.processingPayment(orderId);
+        log.info("[DEBUG] processingPayment UPDATE 결과 - 영향받은 row 수: " + updated);
+        if (updated == 0) {
+            log.error("[경고] 결제 상태를 PROCESSING으로 바꾸지 못했습니다. - 예상 상태(READY) 아님. orderId: " + orderId);
+        }
+    }
+
+    @Transactional
+    public boolean claimForCancel(String orderId) {
+        PaymentsVO payment = getPayment(orderId);
+        String status = payment.getStatus();
+        
+        if (!"DONE".equals(status)) {
+            // DONE이 아니면 취소 불가 - READY/PROCESSING/CANCELED/CANCEL_PROCESSING/FAIL 등
+            log.info("취소 불가 상태 [status: " + status + "] - orderId: " + orderId);
+            return false;
+        }
+        int updated = updatePaymentCancleProcessing(orderId);
+        if (updated == 0) {
+            log.error("[경고] 결제 상태를 CANCEL_PROCESSING으로 바꾸지 못했습니다. - 예상 상태(DONE) 아님. orderId: " + orderId);
+            return false;
+        }
+        return true;
+    }
+    
+    private int updatePaymentCancleProcessing(String orderId) {
+        return paymentsDao.CancelProcessingPayment(orderId);
+    }
+
+    public void revertCancelProcessing(String orderId) {
+        paymentsDao.revertCancelProcessing(orderId);
     }
 }

--- a/src/main/java/com/petcation/common/config/TransactionConfig.java
+++ b/src/main/java/com/petcation/common/config/TransactionConfig.java
@@ -1,0 +1,10 @@
+package com.petcation.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class TransactionConfig {
+    
+}

--- a/src/main/resources/query/Payments.xml
+++ b/src/main/resources/query/Payments.xml
@@ -22,6 +22,7 @@
 			status= 'DONE', 
 			approved_at = CURRENT_TIMESTAMP
 		WHERE order_id = #{orderId}
+			AND status = 'PROCESSING'
 	</update>
 	
 	<update id="failPayment">
@@ -38,6 +39,7 @@
 			status = 'CANCELED',
 			approved_at = CURRENT_TIMESTAMP
 		WHERE order_id = #{orderId} 
+			AND status = 'CANCEL_PROCESSING'
 	</update>
 	
 	<select id="getPaymentKey" resultType="String">
@@ -45,4 +47,29 @@
 		FROM payments
 		WHERE order_id = #{orderId}
 	</select>
+	
+	<update id="processingPayment">
+		UPDATE payments
+		SET
+			status = 'PROCESSING',
+			approved_at = CURRENT_TIMESTAMP
+		WHERE order_id = #{orderId}
+			AND status = 'READY'
+	</update>
+	
+	<update id="CancelProcessingPayment">
+		UPDATE payments
+		SET
+			status = 'CANCEL_PROCESSING',
+			approved_at = CURRENT_TIMESTAMP
+		WHERE order_id = #{orderId}
+			AND status = 'DONE'
+	</update>
+	
+	<update id="revertCancelProcessing">
+	    UPDATE payments
+	    SET status = 'DONE'
+	    WHERE order_id = #{orderId}
+	      AND status = 'CANCEL_PROCESSING'
+	</update>
 </mapper>

--- a/src/main/webapp/WEB-INF/spring/root-context.xml
+++ b/src/main/webapp/WEB-INF/spring/root-context.xml
@@ -7,11 +7,16 @@
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.3.xsd">
 	
+	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+	    <property name="dataSource" ref="dataSource" />
+	</bean>
+	<bean class="com.petcation.common.config.TransactionConfig" />
+	
 	<bean id="hikariConfig" class="com.zaxxer.hikari.HikariConfig">
 		<property name="driverClassName" value="net.sf.log4jdbc.sql.jdbcapi.DriverSpy" />
-		<property name="jdbcUrl" value="jdbc:log4jdbc:oracle:thin:@localhost:1521/xepdb1" />
-		<property name="username" value="petcation" />
-		<property name="password" value="pet1234" />
+		<property name="jdbcUrl" value="${db.url}" />
+    	<property name="username" value="${db.username}" />
+    	<property name="password" value="${db.password}" />
 	</bean>
 
 	<bean id="dataSource" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">


### PR DESCRIPTION
## 개요
결제 confirm/webhook 동시 요청 시 발생할 수 있는 중복 처리 문제를 방어하고, 전역적으로 @Transactional이 동작하지 않던 문제를 해결했습니다.

## 변경 사항
- `@EnableTransactionManagement` 기반 `TransactionConfig` 추가
- `claimForProcessing`/`claimForCancel`로 상태 선점 패턴 도입
  (DB 비관적 락 + 조건부 UPDATE로 상태 전이 제어)
- `PaymentValidator`에 `PROCESSING` 상태 체크 추가
- 취소 실패 시 상태 복구 로직 추가
